### PR TITLE
Update to kotlin 1.3.50

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 
 jobs:
   include:
-    - name: Http
+    - name: Streams
         env:
           - JAVA_OPTS="-XX:MaxPermSize=1024m -XX:+CMSClassUnloadingEnabled -XX:+HeapDumpOnOutOfMemoryError -Xmx2048m"
         language: android
@@ -24,4 +24,4 @@ jobs:
           - chmod +x gradlew
           - chmod +x gradle/wrapper/gradle-wrapper.jar
         script:
-          - ./gradlew test jvmTest --parallel
+          - ./gradlew test jvmTest ktlintCheck --parallel

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Trikot.http
+**Incubating**
 
 Multiplaform http networking abstraction.
 - Default implementation uses [ktor](https://ktor.io/) underneath
@@ -39,11 +40,11 @@ Values are `WIFI`, `CELLULAR`, `NONE`
 ## Installation
 ##### Import dependencies
 ```groovy
-    api "com.mirego.trikot:http:$trikot_kword_version"
-    jvm "com.mirego.trikot:http-jvm:$trikot_kword_version"
-    js "com.mirego.trikot:http-js:$trikot_kword_version"
-    iosx64 "com.mirego.trikot:http-iosx64:$trikot_kword_version"
-    iosarm64 "com.mirego.trikot:http-iosarm64:$trikot_kword_version"
+    api "com.mirego.trikot:http:$trikot_http_version"
+    jvm "com.mirego.trikot:http-jvm:$trikot_http_version"
+    js "com.mirego.trikot:http-js:$trikot_http_version"
+    iosx64 "com.mirego.trikot:http-iosx64:$trikot_http_version"
+    iosarm64 "com.mirego.trikot:http-iosarm64:$trikot_http_version"
 ```
 
 ##### Setup platforms

--- a/android-ktx/README.md
+++ b/android-ktx/README.md
@@ -7,11 +7,24 @@ dependencies {
 }
 ```
 
-# Setup connectivity publisher
+##### Setup HTTPRequestFactory Implementation based on [Ktor](https://github.com/ktorio/ktor)
+Trikot.http android-ktx provides its own implementation based on `Ktor`
 
+```kotlin
+class MyAndroidApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        HttpConfiguration().httpRequestFactory = KtorHttpRequestFactory()
+    }
+}
+```
+
+# Setup connectivity publisher
+```kotlin
 class MyAndroidApplication : Application() {
     override fun onCreate() {
         super.onCreate()
         HttpConfiguration.connectivityPublisher = AndroidConnectivityPublisher(this).distinctUntilChanged()
     }
 }
+```

--- a/android-ktx/build.gradle
+++ b/android-ktx/build.gradle
@@ -35,6 +35,7 @@ configurations.all {
 dependencies {
     api 'com.mirego.trikot:streams:0.22.1'
     api 'com.mirego.trikot:http:0.1.1'
+    implementation "io.ktor:ktor-client-android:$ktor_version"
     implementation 'androidx.lifecycle:lifecycle-extensions:2.0.0'
     implementation 'androidx.lifecycle:lifecycle-reactivestreams-ktx:2.0.0'
 }

--- a/android-ktx/src/main/java/com/mirego/trikot/http/android/ktx/KtorHttpRequestFactory.kt
+++ b/android-ktx/src/main/java/com/mirego/trikot/http/android/ktx/KtorHttpRequestFactory.kt
@@ -1,4 +1,4 @@
-package com.mirego.trikot.http.requestFactory
+package com.mirego.trikot.http.android.ktx.requestFactory
 
 import com.mirego.trikot.http.HttpRequest
 import com.mirego.trikot.http.HttpRequestFactory

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.41'
+    ext.kotlin_version = '1.3.50'
 
     repositories {
         google()
@@ -11,7 +11,6 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.4.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "org.jetbrains.kotlin:kotlin-native-gradle-plugin:$kotlin_version"
         classpath 'io.fabric.tools:gradle:1.29.0'
         classpath 'org.jlleitschuh.gradle:ktlint-gradle:8.0.0'
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 kotlin.code.style=official
-kotlin_version = 1.3.41
-trikot_foundation_version=0.0.1
-trikot_streams_version=0.22.1
+kotlin_version = 1.3.50
+trikot_foundation_version=0.1.1
+trikot_streams_version=0.24.1
 ktor_version = 1.2.2
-serialization_version=0.11.1
+serialization_version=0.12.0
 android.useAndroidX=true
 android.enableJetifier=true
 kapt.incremental.apt=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/http/build.gradle
+++ b/http/build.gradle
@@ -31,7 +31,6 @@ kotlin {
                 implementation "com.mirego.trikot:foundation:$trikot_foundation_version"
                 implementation 'org.jetbrains.kotlin:kotlin-stdlib-common'
                 implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime-common:$serialization_version"
-                implementation "io.ktor:ktor-client-core:$ktor_version"
             }
         }
         jvmMain {
@@ -40,7 +39,6 @@ kotlin {
                 implementation "com.mirego.trikot:foundation-jvm:$trikot_foundation_version"
                 implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
                 implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime:$serialization_version"
-                implementation "io.ktor:ktor-client-android:$ktor_version"
             }
         }
         jsMain {
@@ -48,7 +46,6 @@ kotlin {
                 implementation "com.mirego.trikot:streams-js:$trikot_streams_version"
                 implementation "com.mirego.trikot:foundation-js:$trikot_foundation_version"
                 implementation 'org.jetbrains.kotlin:kotlin-stdlib-js'
-                implementation "io.ktor:ktor-client-js:$ktor_version"
                 implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime-js:$serialization_version"
             }
         }
@@ -61,7 +58,6 @@ kotlin {
             dependencies {
                 implementation "com.mirego.trikot:streams-iosarm64:$trikot_streams_version"
                 implementation "com.mirego.trikot:foundation-iosarm64:$trikot_foundation_version"
-                implementation "io.ktor:ktor-client-ios:$ktor_version"
                 implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime-native:$serialization_version"
             }
         }
@@ -71,7 +67,6 @@ kotlin {
             dependencies {
                 implementation "com.mirego.trikot:streams-iosx64:$trikot_streams_version"
                 implementation "com.mirego.trikot:foundation-iosx64:$trikot_foundation_version"
-                implementation "io.ktor:ktor-client-ios:$ktor_version"
                 implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime-native:$serialization_version"
             }
         }

--- a/http/src/commonMain/kotlin/com/mirego/trikot/http/HttpConfiguration.kt
+++ b/http/src/commonMain/kotlin/com/mirego/trikot/http/HttpConfiguration.kt
@@ -9,11 +9,13 @@ import com.mirego.trikot.streams.reactive.Publishers
 import kotlinx.serialization.UnstableDefault
 import kotlinx.serialization.json.Json
 import org.reactivestreams.Publisher
-import com.mirego.trikot.http.requestFactory.KtorHttpRequestFactory
 import com.mirego.trikot.http.header.DefaultHttpHeaderProvider
+import com.mirego.trikot.http.requestFactory.EmptyHttpRequestFactory
 
 object HttpConfiguration {
-    private val internalHttpRequestFactory = AtomicReference<HttpRequestFactory>(KtorHttpRequestFactory())
+    private val internalHttpRequestFactory = AtomicReference<HttpRequestFactory>(
+        EmptyHttpRequestFactory()
+    )
     private val internalNetworkDispatchQueue = AtomicReference<DispatchQueue>(OperationDispatchQueue())
     private val internalDefaultHeaderProvider = AtomicReference<HttpHeaderProvider>(DefaultHttpHeaderProvider())
     private val internalConnectivityStatePublisher = AtomicReference<Publisher<ConnectivityState>>(Publishers.behaviorSubject(

--- a/http/src/commonMain/kotlin/com/mirego/trikot/http/requestFactory/EmptyHttpRequestFactory.kt
+++ b/http/src/commonMain/kotlin/com/mirego/trikot/http/requestFactory/EmptyHttpRequestFactory.kt
@@ -1,0 +1,12 @@
+package com.mirego.trikot.http.requestFactory
+
+import com.mirego.trikot.http.HttpRequest
+import com.mirego.trikot.http.HttpRequestFactory
+import com.mirego.trikot.http.RequestBuilder
+
+class EmptyHttpRequestFactory : HttpRequestFactory {
+    override fun request(requestBuilder: RequestBuilder): HttpRequest {
+        TODO("HTTPConfiguration.httpRequestFactory must be set before sending request." +
+                " See: https://github.com/mirego/trikot.http/blob/master/README.md")
+    }
+}

--- a/swift-extensions/README.md
+++ b/swift-extensions/README.md
@@ -8,7 +8,7 @@ To use `Trikot.http` swift extensions, you must export `http` and `http-iosx64` 
 ```
 Then, run `pod install`.
 
-##### HTTPRequestFactory Implementation based on `URLSession`
+##### Setup HTTPRequestFactory Implementation based on `URLSession`
 `ktor` does not work that well on iOS as it relies on Coroutines on the mainThread (as of today). Trikot.http provides its own implementation based on `URLSession`
 
 ```swift


### PR DESCRIPTION
Update to Kotlin 1.3.50

As `Ktor` is using an old version of gradle, its now incompatible with Konan and cannot be compiled for iosX64 and Arm64. As a workaround, we provide the `Ktor` implementation for Android and creates an empty HttpRequestFactory that cannot be used. `Ktor` is available trough `trikot.http android-ktx`