### PR TITLE
Add HttpStatusCode enum

### DIFF
--- a/http/src/commonMain/kotlin/com/mirego/trikot/http/HttpStatusCode.kt
+++ b/http/src/commonMain/kotlin/com/mirego/trikot/http/HttpStatusCode.kt
@@ -1,6 +1,8 @@
 package com.mirego.trikot.http
 
 enum class HttpStatusCode(val statusCode: Int) {
+    UNKNOWN(0),
+
     CONTINUE(100),
     SWITCHING_PROTOCOLS(101),
     PROCESSING(102),
@@ -82,6 +84,6 @@ enum class HttpStatusCode(val statusCode: Int) {
 
     companion object {
         private val map = values().associateBy(HttpStatusCode::statusCode)
-        fun fromInt(type: Int) = map[type] ?: INTERNAL_SERVER_ERROR
+        fun fromInt(type: Int) = map[type] ?: UNKNOWN
     }
 }


### PR DESCRIPTION
We add a new enumeration to match on status code. Should I convert also the HttpResponse class directly? We could return that enum instead of int.