### PR TITLE
Support byte array and text bodys for request

### DIFF
--- a/android-ktx/build.gradle
+++ b/android-ktx/build.gradle
@@ -35,7 +35,7 @@ configurations.all {
 
 dependencies {
     api "com.mirego.trikot:streams:$trikot_streams_version"
-    api 'com.mirego.trikot:http:0.8.1'
+    api 'com.mirego.trikot:http:0.10.1'
     implementation "io.ktor:ktor-client-android:$ktor_version"
     implementation 'androidx.lifecycle:lifecycle-extensions:2.0.0'
     implementation 'androidx.lifecycle:lifecycle-reactivestreams-ktx:2.0.0'

--- a/android-ktx/src/main/java/com/mirego/trikot/http/android/ktx/KtorHttpRequestFactory.kt
+++ b/android-ktx/src/main/java/com/mirego/trikot/http/android/ktx/KtorHttpRequestFactory.kt
@@ -1,15 +1,13 @@
 package com.mirego.trikot.http.android.ktx.requestFactory
 
-import com.mirego.trikot.http.HttpRequest
-import com.mirego.trikot.http.HttpRequestFactory
-import com.mirego.trikot.http.HttpResponse
-import com.mirego.trikot.http.RequestBuilder
+import com.mirego.trikot.http.*
 import com.mirego.trikot.streams.cancellable.CancellableManager
 import com.mirego.trikot.streams.reactive.Publishers
 import io.ktor.client.HttpClient
 import io.ktor.client.request.header
 import io.ktor.client.request.request
 import io.ktor.client.request.url
+import io.ktor.content.ByteArrayContent
 import io.ktor.content.TextContent
 import io.ktor.http.ContentType
 import io.ktor.http.HttpMethod
@@ -35,10 +33,23 @@ class KtorHttpRequestFactory : HttpRequestFactory {
                 try {
                     val response = client.request<String> {
                         url(requestBuilder.baseUrl + requestBuilder.path)
-                        requestBuilder.headers.filter { it.key != com.mirego.trikot.http.ContentType }.forEach { entry ->
-                            header(entry.key, entry.value)
+                        requestBuilder.headers.filter { it.key != com.mirego.trikot.http.ContentType }
+                            .forEach { entry ->
+                                header(entry.key, entry.value)
+                            }
+                        requestBuilder.body?.let {
+                            if (it is ByteArray) {
+                                val contentType =
+                                    requestBuilder.headers[com.mirego.trikot.http.ContentType]
+                                        ?: ApplicationOctetStream
+                                body = ByteArrayContent(it, ContentType.parse(contentType))
+                            } else if (it is String) {
+                                val contentType =
+                                    requestBuilder.headers[com.mirego.trikot.http.ContentType]
+                                        ?: ApplicationJSON
+                                body = TextContent(it, ContentType.parse(contentType))
+                            }
                         }
-                        requestBuilder.body?.let { body = TextContent(it as String, ContentType.Application.Json) }
                         method = requestBuilder.method.ktorMethod
                     }
 

--- a/swift-extensions/TrikotHttpRequest.swift
+++ b/swift-extensions/TrikotHttpRequest.swift
@@ -19,7 +19,9 @@ public class TrikotHttpRequest: NSObject, HttpRequest {
                 urlRequest.setValue(value, forHTTPHeaderField: key)
             }
 
-            if let body = requestBuilder.body as? String {
+            if let body = requestBuilder.body as? KotlinByteArray {
+                urlRequest.httpBody = ByteArrayNativeUtils().convert(byteArray: body)
+            } else if let body = requestBuilder.body as? String {
                 urlRequest.httpBody = body.data(using: .utf8)
             }
 


### PR DESCRIPTION
We only supported sending string body so it was impossible to send raw data using http request.

We now handle String and ByteArray and send the correct `Content-Type`.