### PR TITLE
Modify kotlin version to 1.3.60

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,17 +1,14 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
-
     repositories {
         google()
         jcenter()
         maven { url "https://plugins.gradle.org/m2/" }
-        maven { url 'https://maven.fabric.io/public' }
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.android.tools.build:gradle:3.5.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'io.fabric.tools:gradle:1.29.0'
+        classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
         classpath 'org.jlleitschuh.gradle:ktlint-gradle:8.0.0'
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,10 @@
 kotlin.code.style=official
-kotlin_version=1.3.50
-trikot_foundation_version=0.14.1
-trikot_streams_version=0.40.1
+kotlin_version=1.3.60
+kotlin.native.version=1.3.60
+trikot_foundation_version=0.16.1
+trikot_streams_version=0.45.1
 ktor_version=1.2.4
-serialization_version=0.12.0
+serialization_version=0.14.0-1.3.60-eap-76
 android.useAndroidX=true
 android.enableJetifier=true
 kapt.incremental.apt=true

--- a/http/build.gradle
+++ b/http/build.gradle
@@ -23,6 +23,8 @@ kotlin {
 
         fromPreset(presets.iosArm64, 'iosArm64')
         fromPreset(presets.iosX64, 'iosX64')
+        fromPreset(presets.tvosArm64, 'tvosArm64')
+        fromPreset(presets.tvosX64, 'tvosX64')
     }
     sourceSets {
         commonMain {
@@ -70,6 +72,24 @@ kotlin {
                 implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime-native:$serialization_version"
             }
         }
+
+        tvosArm64Main {
+            dependsOn(nativeMain)
+            dependencies {
+                implementation "com.mirego.trikot:streams-tvosarm64:$trikot_streams_version"
+                implementation "com.mirego.trikot:foundation-tvosarm64:$trikot_foundation_version"
+                implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime-native:$serialization_version"
+            }
+        }
+
+        tvosX64Main {
+            dependsOn(nativeMain)
+            dependencies {
+                implementation "com.mirego.trikot:streams-tvosx64:$trikot_streams_version"
+                implementation "com.mirego.trikot:foundation-tvosx64:$trikot_foundation_version"
+                implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime-native:$serialization_version"
+            }
+        }    
     }
 }
 


### PR DESCRIPTION
Modify kotlin version to 1.3.60. Need to use an eap version for kotlinx serialization released in the main repository.