### PR TITLE
Changed the way HTTP error are handled and returned so that the error details can be used by the caller.

### DIFF
--- a/http/src/commonMain/kotlin/com/mirego/trikot/http/HttpResponseException.kt
+++ b/http/src/commonMain/kotlin/com/mirego/trikot/http/HttpResponseException.kt
@@ -1,0 +1,5 @@
+package com.mirego.trikot.http
+
+class HttpResponseException(
+    val httpResponse: HttpResponse
+) : Exception("HTTP error ${httpResponse.statusCode}")

--- a/http/src/commonMain/kotlin/com/mirego/trikot/http/requestPublisher/DeserializableHttpRequestPublisher.kt
+++ b/http/src/commonMain/kotlin/com/mirego/trikot/http/requestPublisher/DeserializableHttpRequestPublisher.kt
@@ -3,6 +3,7 @@ package com.mirego.trikot.http.requestPublisher
 import com.mirego.trikot.http.HttpConfiguration
 import com.mirego.trikot.http.HttpHeaderProvider
 import com.mirego.trikot.http.HttpResponse
+import com.mirego.trikot.http.HttpResponseException
 import com.mirego.trikot.http.RequestBuilder
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.UnstableDefault
@@ -15,6 +16,13 @@ open class DeserializableHttpRequestPublisher<T>(
 
     @UseExperimental(UnstableDefault::class)
     override fun processResponse(response: HttpResponse): T {
+        when (response.statusCode) {
+            in 200..299 -> return successfulResponse(response)
+            else -> throw HttpResponseException(response)
+        }
+    }
+
+    private fun successfulResponse(response: HttpResponse): T {
         response.bodyString?.let { bodyString ->
             return HttpConfiguration.json.parse(deserializer, bodyString)
         }


### PR DESCRIPTION
## Description
HTTP errors were not properly returned to the caller, and behavior was not the same on Android and iOS implementation of the request.

## Motivation and Context
When receiving non-2xx HTTP status code, the details of the response was lost before reaching the caller of the HttpRequestPublisher. So it was impossible to take proper action depending on HTTP error, which is a common use case.

Additionally, the behavior was different on both Android and iOS. Here was the flow prior to this modification:

Android:
  - HTTP server returns error code (for instance 400)
  - KTOR Android throws a specific Exception, containing the details of the response (the implementation of this Exception is Android-specific)
  - The Exception is thrown up to the HttpRequestPublisher
  - `onErroReturn()` is called on exposed Pubisher, with the Exception. However, since the actual implementation is Android-specific, common code can do nothing with it, and can only get the Exception message, without knowing more.

iOS:
  - HTTP server returns error code (for instance 400)
  - iOS low level HTTP layer simply returns the response (not considered an error at the http level).
  - The response bubbles up to the DeserializableHttpRequestPublisher, that attempts to parse the body.
  - Parsing fail (body is not as expected), an Exception is thrown
  - `onErroReturn()` is called on the caller, with the parsing exception. 

Now, when receiving a non-2xx response, an HttpResponseException is received in `onErroReturn`, which contains the actual HttpResponse. The caller then get access to the error code and the response body.

## How Has This Been Tested?
This was tested an actual application, on both Android and iOS.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

This shouldn't impact other projects, since in the end the behavior remains the same: `onErrorReturn` gets called. The Exception is only more relevant. 
