### PR TITLE
Added the (optional) possbility to specify a Logger and a LogLevel of http traffic. (android only)

### DIFF
--- a/android-ktx/build.gradle
+++ b/android-ktx/build.gradle
@@ -35,8 +35,9 @@ configurations.all {
 
 dependencies {
     api "com.mirego.trikot:streams:$trikot_streams_version"
-    api 'com.mirego.trikot:http:0.13.1'
+    api 'com.mirego.trikot:http:0.14.1'
     implementation "io.ktor:ktor-client-android:$ktor_version"
+    api "io.ktor:ktor-client-logging-jvm:$ktor_version"
     implementation 'androidx.lifecycle:lifecycle-extensions:2.1.0'
     implementation 'androidx.lifecycle:lifecycle-reactivestreams-ktx:2.1.0'
 }


### PR DESCRIPTION
## Description
Logging HTTP traffic is a frequent need. KTOR has a plugin that does just that, so we simply adds new parameters at initiaization to configure this logger.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
