### PR TITLE
Upgrade to kotlin 1.3.61, Gradle 5.6.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:3.5.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
         classpath 'org.jlleitschuh.gradle:ktlint-gradle:8.0.0'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,7 @@
 kotlin.code.style=official
-kotlin_version=1.3.60
-kotlin.native.version=1.3.60
-trikot_foundation_version=0.18.1
-trikot_streams_version=0.48.1
+kotlin_version=1.3.61
+trikot_foundation_version=0.25.1
+trikot_streams_version=0.49.1
 ktor_version=1.2.4
 serialization_version=0.14.0
 android.useAndroidX=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/http/src/commonMain/kotlin/com/mirego/trikot/http/HttpConfiguration.kt
+++ b/http/src/commonMain/kotlin/com/mirego/trikot/http/HttpConfiguration.kt
@@ -81,5 +81,5 @@ object HttpConfiguration {
      * Shared JSON parser used by DeserializableHttpRequestPublisher
      */
     @UseExperimental(UnstableDefault::class)
-    val json = freeze(Json.nonstrict)
+    val json = Json.nonstrict.also { freeze(it) }
 }

--- a/swift-extensions/TrikotHttpRequest.swift
+++ b/swift-extensions/TrikotHttpRequest.swift
@@ -45,7 +45,8 @@ public class TrikotHttpRequest: NSObject, HttpRequest {
             resultPublisher.error = KotlinThrowable(message: "Unable to create a valid URL")
         }
 
-        return MrFreeze().freeze(objectToFreeze: resultPublisher) as! Publisher
+        MrFreeze().freeze(objectToFreeze: resultPublisher)
+        return resultPublisher
     }
 }
 


### PR DESCRIPTION
## Description
I'll update foundation and streams dependencies once built

## Motivation and Context
After reading code from memory.cpp, I think we should not use the return of `freeze` method to keep the reference as it seems boxed. I am not 💯 sure of this but I prefer to go this way to make sure we are future proof.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
