### PR TITLE
Include JsName decorator to have constant naming in JavaScript

### DIFF
--- a/http/src/commonMain/kotlin/com/mirego/trikot/http/HttpHeaderProvider.kt
+++ b/http/src/commonMain/kotlin/com/mirego/trikot/http/HttpHeaderProvider.kt
@@ -2,6 +2,7 @@ package com.mirego.trikot.http
 
 import com.mirego.trikot.streams.cancellable.CancellableManager
 import org.reactivestreams.Publisher
+import kotlin.js.JsName
 
 interface HttpHeaderProvider {
     /**
@@ -10,11 +11,13 @@ interface HttpHeaderProvider {
      * @param requestBuilder Request to sent
      * @return Publisher of headers to sent with the requestBuilder
      */
+    @JsName("headerForURLRequest")
     fun headerForURLRequest(cancellableManager: CancellableManager, requestBuilder: RequestBuilder): Publisher<Map<String, String>>
     /**
      * This method is called on every error received by HttpRequestPublisher to let the HttpHeaderProvider modify, cleanup or refresh the headers for the next request.
      * @param requestBuilder Request that failed
      * @param error Error received from the HttpRequestPublisher
      */
+    @JsName("processHttpError")
     fun processHttpError(requestBuilder: RequestBuilder, error: Throwable)
 }

--- a/http/src/commonMain/kotlin/com/mirego/trikot/http/HttpRequest.kt
+++ b/http/src/commonMain/kotlin/com/mirego/trikot/http/HttpRequest.kt
@@ -2,7 +2,9 @@ package com.mirego.trikot.http
 
 import com.mirego.trikot.streams.cancellable.CancellableManager
 import org.reactivestreams.Publisher
+import kotlin.js.JsName
 
 interface HttpRequest {
+    @JsName("execute")
     fun execute(cancellableManager: CancellableManager): Publisher<HttpResponse>
 }

--- a/http/src/commonMain/kotlin/com/mirego/trikot/http/HttpRequestFactory.kt
+++ b/http/src/commonMain/kotlin/com/mirego/trikot/http/HttpRequestFactory.kt
@@ -1,10 +1,13 @@
 package com.mirego.trikot.http
 
+import kotlin.js.JsName
+
 interface HttpRequestFactory {
     /**
      * Create an HttpRequest for a request builder
      * @param requestBuilder RequestBuilder to create a HttpRequest for
      * @return A ready to be executed HttpRequest
      */
+    @JsName("request")
     fun request(requestBuilder: RequestBuilder): HttpRequest
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Include `@JsName` to methods used on the web platform.

## Motivation and Context

Without these decorators, methods are exposed with an inconsistant naming, like `request_iis1eb$(requestBuilder)` instead of `request(requestBuilder)`.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
