### PR TITLE
Update trikot.streams

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 kotlin_version=1.3.61
 trikot_foundation_version=0.25.1
-trikot_streams_version=0.49.1
+trikot_streams_version=0.54.1
 ktor_version=1.2.4
 serialization_version=0.14.0
 android.useAndroidX=true


### PR DESCRIPTION
## Motivation and Context

Since trikot.stream now have @JsName over its methods, datasources have to use this version of stream to work on the web.
