### PR TITLE
Lower min sdk version on android

### DIFF
--- a/android-ktx/build.gradle
+++ b/android-ktx/build.gradle
@@ -24,7 +24,7 @@ android {
     buildToolsVersion "29.0.2"
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 14
         targetSdkVersion 29
     }
 }

--- a/android-ktx/src/main/java/com/mirego/trikot/http/android/ktx/AndroidConnectivityPublisher.kt
+++ b/android-ktx/src/main/java/com/mirego/trikot/http/android/ktx/AndroidConnectivityPublisher.kt
@@ -1,14 +1,18 @@
 package com.mirego.trikot.http.android.ktx
 
+import android.annotation.TargetApi
 import android.content.Context
 import android.content.ContextWrapper
 import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
+import android.os.Build
+import androidx.annotation.RequiresApi
 import com.mirego.trikot.http.connectivity.ConnectivityState
 import com.mirego.trikot.streams.reactive.BehaviorSubjectImpl
 
+@RequiresApi(Build.VERSION_CODES.LOLLIPOP)
 class AndroidConnectivityPublisher(application: ContextWrapper) :
     BehaviorSubjectImpl<ConnectivityState>() {
 
@@ -58,6 +62,7 @@ class AndroidConnectivityPublisher(application: ContextWrapper) :
     }
 }
 
+@RequiresApi(Build.VERSION_CODES.LOLLIPOP)
 private fun NetworkCapabilities.asConnectivityState(): ConnectivityState {
     return when {
         hasTransport(NetworkCapabilities.TRANSPORT_WIFI) ||

--- a/android-ktx/src/main/java/com/mirego/trikot/http/android/ktx/AndroidConnectivityPublisher.kt
+++ b/android-ktx/src/main/java/com/mirego/trikot/http/android/ktx/AndroidConnectivityPublisher.kt
@@ -22,9 +22,9 @@ class AndroidConnectivityPublisher(application: ContextWrapper) :
 
     private val networkCallback = object : ConnectivityManager.NetworkCallback() {
 
-        override fun onAvailable(network: Network?) {
+        override fun onAvailable(network: Network) {
             super.onAvailable(network)
-            value = connectivityManager.getNetworkCapabilities(network).asConnectivityState()
+            value = connectivityManager.getNetworkCapabilities(network)?.asConnectivityState()
         }
 
         override fun onCapabilitiesChanged(
@@ -35,7 +35,7 @@ class AndroidConnectivityPublisher(application: ContextWrapper) :
             value = networkCapabilities.asConnectivityState()
         }
 
-        override fun onLost(network: Network?) {
+        override fun onLost(network: Network) {
             super.onLost(network)
             val isConnected = connectivityManager.activeNetworkInfo?.isConnected == true
             if (!isConnected) value = ConnectivityState.NONE


### PR DESCRIPTION
## Description
No actual code change had to be done.
The connectivity publisher is marked API 21+ for now.

## Motivation and Context
I needed to have API 19+ in my project. I lowered it even more since there was no reason not to.

## How Has This Been Tested?
Tested it in my project with min sdk api level 19

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
