### PR TITLE
Fix AndroidConnectivityPublisher not calling back when subscribing while offline

### DIFF
--- a/android-ktx/src/main/java/com/mirego/trikot/http/android/ktx/AndroidConnectivityPublisher.kt
+++ b/android-ktx/src/main/java/com/mirego/trikot/http/android/ktx/AndroidConnectivityPublisher.kt
@@ -1,6 +1,6 @@
 package com.mirego.trikot.http.android.ktx
 
-import android.annotation.TargetApi
+import android.Manifest
 import android.content.Context
 import android.content.ContextWrapper
 import android.net.ConnectivityManager
@@ -9,11 +9,14 @@ import android.net.NetworkCapabilities
 import android.net.NetworkRequest
 import android.os.Build
 import androidx.annotation.RequiresApi
+import androidx.annotation.RequiresPermission
 import com.mirego.trikot.http.connectivity.ConnectivityState
 import com.mirego.trikot.streams.reactive.BehaviorSubjectImpl
 
 @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
-class AndroidConnectivityPublisher(application: ContextWrapper) :
+class AndroidConnectivityPublisher @RequiresPermission(Manifest.permission.ACCESS_NETWORK_STATE) constructor(
+    application: ContextWrapper
+) :
     BehaviorSubjectImpl<ConnectivityState>() {
 
     private val connectivityManager: ConnectivityManager =
@@ -66,8 +69,8 @@ class AndroidConnectivityPublisher(application: ContextWrapper) :
 private fun NetworkCapabilities.asConnectivityState(): ConnectivityState {
     return when {
         hasTransport(NetworkCapabilities.TRANSPORT_WIFI) ||
-            hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)
-            || hasTransport(NetworkCapabilities.TRANSPORT_VPN) -> ConnectivityState.WIFI
+                hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)
+                || hasTransport(NetworkCapabilities.TRANSPORT_VPN) -> ConnectivityState.WIFI
         else -> ConnectivityState.CELLULAR
     }
 }

--- a/android-ktx/src/main/java/com/mirego/trikot/http/android/ktx/AndroidConnectivityPublisher.kt
+++ b/android-ktx/src/main/java/com/mirego/trikot/http/android/ktx/AndroidConnectivityPublisher.kt
@@ -1,26 +1,34 @@
 package com.mirego.trikot.http.android.ktx
 
-import android.Manifest
 import android.content.Context
 import android.content.ContextWrapper
 import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
+import android.net.NetworkInfo
 import android.net.NetworkRequest
 import android.os.Build
 import androidx.annotation.RequiresApi
-import androidx.annotation.RequiresPermission
 import com.mirego.trikot.http.connectivity.ConnectivityState
 import com.mirego.trikot.streams.reactive.BehaviorSubjectImpl
 
 @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
-class AndroidConnectivityPublisher @RequiresPermission(Manifest.permission.ACCESS_NETWORK_STATE) constructor(
-    application: ContextWrapper
-) :
+class AndroidConnectivityPublisher(application: ContextWrapper) :
     BehaviorSubjectImpl<ConnectivityState>() {
 
     private val connectivityManager: ConnectivityManager =
         application.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+
+    private val activeNetworkState: ConnectivityState
+        get() {
+            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork)
+                    ?.asConnectivityState()
+            } else {
+                @Suppress("DEPRECATION")
+                connectivityManager.activeNetworkInfo?.asConnectivityState()
+            } ?: ConnectivityState.NONE
+        }
 
     private val networkRequest =
         NetworkRequest.Builder()
@@ -32,6 +40,7 @@ class AndroidConnectivityPublisher @RequiresPermission(Manifest.permission.ACCES
         override fun onAvailable(network: Network) {
             super.onAvailable(network)
             value = connectivityManager.getNetworkCapabilities(network)?.asConnectivityState()
+                ?: ConnectivityState.NONE
         }
 
         override fun onCapabilitiesChanged(
@@ -50,12 +59,12 @@ class AndroidConnectivityPublisher @RequiresPermission(Manifest.permission.ACCES
     }
 
     init {
-        val isConnected = connectivityManager.activeNetworkInfo?.isConnected == true
-        if (!isConnected) value = ConnectivityState.NONE
+        value = activeNetworkState
     }
 
     override fun onFirstSubscription() {
         super.onFirstSubscription()
+        value = activeNetworkState
         connectivityManager.registerNetworkCallback(networkRequest, networkCallback)
     }
 
@@ -66,11 +75,17 @@ class AndroidConnectivityPublisher @RequiresPermission(Manifest.permission.ACCES
 }
 
 @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
-private fun NetworkCapabilities.asConnectivityState(): ConnectivityState {
-    return when {
-        hasTransport(NetworkCapabilities.TRANSPORT_WIFI) ||
-                hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)
-                || hasTransport(NetworkCapabilities.TRANSPORT_VPN) -> ConnectivityState.WIFI
-        else -> ConnectivityState.CELLULAR
-    }
+private fun NetworkCapabilities.asConnectivityState() = when {
+    hasTransport(NetworkCapabilities.TRANSPORT_WIFI) ||
+        hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)
+        || hasTransport(NetworkCapabilities.TRANSPORT_VPN) -> ConnectivityState.WIFI
+    else -> ConnectivityState.CELLULAR
+}
+
+@Suppress("DEPRECATION")
+private fun NetworkInfo.asConnectivityState() = when (type) {
+    ConnectivityManager.TYPE_MOBILE -> ConnectivityState.CELLULAR
+    ConnectivityManager.TYPE_WIFI -> ConnectivityState.WIFI
+    ConnectivityManager.TYPE_ETHERNET -> ConnectivityState.WIFI
+    else -> ConnectivityState.NONE
 }


### PR DESCRIPTION
## Description
Fixes an issue where we were not having any network state when device went offline after the ConnectivityPublisher was created.

connectivityManager.registerNetworkCallback does not callback if the device is already offline when registering.

## Motivation and Context
We were performing an http request which was silently not returning any errors due to the error handling using connectivity publisher.

## How Has This Been Tested?
Tested in my project

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
