### PR TITLE
Remove default connectivity state

### DIFF
--- a/http/src/commonMain/kotlin/com/mirego/trikot/http/HttpConfiguration.kt
+++ b/http/src/commonMain/kotlin/com/mirego/trikot/http/HttpConfiguration.kt
@@ -18,8 +18,7 @@ object HttpConfiguration {
     )
     private val internalNetworkDispatchQueue = AtomicReference<DispatchQueue>(OperationDispatchQueue())
     private val internalDefaultHeaderProvider = AtomicReference<HttpHeaderProvider>(DefaultHttpHeaderProvider())
-    private val internalConnectivityStatePublisher = AtomicReference<Publisher<ConnectivityState>>(Publishers.behaviorSubject(
-        ConnectivityState.WIFI))
+    private val internalConnectivityStatePublisher = AtomicReference<Publisher<ConnectivityState>>(Publishers.publishSubject())
     private val internalBaseUrl = AtomicReference("")
 
     /**

--- a/swift-extensions/TrikotConnectivityService.swift
+++ b/swift-extensions/TrikotConnectivityService.swift
@@ -4,7 +4,7 @@ import TRIKOT_FRAMEWORK_NAME
 
 public class TrikotConnectivityService {
     public static let shared = TrikotConnectivityService()
-    public let publisher = Publishers().behaviorSubject(value: ConnectivityState.wifi)
+    public let publisher = Publishers().publishSubject()
 
     let reachability = Reachability()!
 
@@ -25,6 +25,7 @@ public class TrikotConnectivityService {
         do {
             try reachability.startNotifier()
         } catch {
+            publisher.value = ConnectivityState.none
             print("Unable to start reachability notifier")
         }
     }


### PR DESCRIPTION
## Description
Remove the default WIFI connectivity state that was set causing strange behaviours when listening to that state at app startup.

## Motivation and Context
When I was starting an app with NoInternet, using this connectivity state before the real state came back from the platform caused a false WIFI state.

## How Has This Been Tested?
In my current app

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
