### PR TITLE
Provide a default value for null baseUrl and path

### DIFF
--- a/android-ktx/src/main/java/com/mirego/trikot/http/android/ktx/requestFactory/KtorHttpRequestFactory.kt
+++ b/android-ktx/src/main/java/com/mirego/trikot/http/android/ktx/requestFactory/KtorHttpRequestFactory.kt
@@ -56,7 +56,7 @@ class KtorHttpRequestFactory(
                 }
                 try {
                     val response = client.request<io.ktor.client.response.HttpResponse> {
-                        url(requestBuilder.baseUrl + requestBuilder.path)
+                        url(requestBuilder.baseUrl ?: "" + requestBuilder.path ?: "")
                         requestBuilder.headers.filter { it.key != com.mirego.trikot.http.ContentType }
                             .forEach { entry ->
                                 header(entry.key, entry.value)


### PR DESCRIPTION
<!--- Describe your changes in detail -->
Omitting the `path` part on a RequestBuilder resulted in a wrong URL on Android

The Native implementation is not affected

## Motivation and Context
On the RequestBuilder object, both the path and the baseUrl are optional. This signals the user that they can be omitted.

These cases where not properly handled in the Ktor implementation of HttpRequestFactory. Passing in `http://www.mirego.com/` for `baseUrl` and nothing for `path` resulted in the following request url `http://www.mirego.com/null`. 

It could be misleading to the user and result in time lost trying to figure out why a request it not sent to the right url

## How Has This Been Tested?
Tested in my project. This should have any side effect.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
