### PR TITLE
New connectivity subscribers now get previous published value if they subscribe after initial value is dispatched

### DIFF
--- a/http/src/commonMain/kotlin/com/mirego/trikot/http/HttpConfiguration.kt
+++ b/http/src/commonMain/kotlin/com/mirego/trikot/http/HttpConfiguration.kt
@@ -18,7 +18,7 @@ object HttpConfiguration {
     )
     private val internalNetworkDispatchQueue = AtomicReference<DispatchQueue>(OperationDispatchQueue())
     private val internalDefaultHeaderProvider = AtomicReference<HttpHeaderProvider>(DefaultHttpHeaderProvider())
-    private val internalConnectivityStatePublisher = AtomicReference<Publisher<ConnectivityState>>(Publishers.publishSubject())
+    private val internalConnectivityStatePublisher = AtomicReference<Publisher<ConnectivityState>>(Publishers.behaviorSubject())
     private val internalBaseUrl = AtomicReference("")
 
     /**

--- a/swift-extensions/TrikotConnectivityService.swift
+++ b/swift-extensions/TrikotConnectivityService.swift
@@ -4,7 +4,7 @@ import TRIKOT_FRAMEWORK_NAME
 
 public class TrikotConnectivityService {
     public static let shared = TrikotConnectivityService()
-    public let publisher = Publishers().publishSubject()
+    public let publisher = Publishers().behaviorSubject(value: nil)
 
     let reachability = Reachability()!
 


### PR DESCRIPTION
## Description
We were using the `publishSubject` instead of the `bahaviorSubject` to publish the connectivity state values. The main difference between both is that a `publishSubject` does NOT dispatch a previous value to a new subscriber but the `bahaviorSubject` does. 

## Motivation and Context
This issue was causing connectivityState listeners that were subscribing too late in the application boot process to never get the initial value of the system.

## How Has This Been Tested?
Tested in my application

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
