### PR TITLE
Fix elvis operator usage in KtorHttpRequestFactory for Android

### DIFF
--- a/android-ktx/src/main/java/com/mirego/trikot/http/android/ktx/requestFactory/KtorHttpRequestFactory.kt
+++ b/android-ktx/src/main/java/com/mirego/trikot/http/android/ktx/requestFactory/KtorHttpRequestFactory.kt
@@ -56,7 +56,7 @@ class KtorHttpRequestFactory(
                 }
                 try {
                     val response = client.request<io.ktor.client.response.HttpResponse> {
-                        url(requestBuilder.baseUrl ?: "" + requestBuilder.path ?: "")
+                        url((requestBuilder.baseUrl ?: "") + (requestBuilder.path ?: ""))
                         requestBuilder.headers.filter { it.key != com.mirego.trikot.http.ContentType }
                             .forEach { entry ->
                                 header(entry.key, entry.value)


### PR DESCRIPTION
Since #21 was merged, all path information was ignored in the request factory since the usage of the elvis operator was wrong. 

`requestBuilder.baseUrl ?: "" + requestBuilder.path ?: ""` translate to take only baseUrl if available  or else take only path.

This PR fix this problem by adding parentheses.