### PR TITLE
Add bodyByteArray to Http response

### DIFF
--- a/android-ktx/build.gradle
+++ b/android-ktx/build.gradle
@@ -15,6 +15,7 @@ repositories {
     maven { url "https://kotlin.bintray.com/kotlinx" }
     maven { url 'https://jitpack.io' }
     maven { url('https://s3.amazonaws.com/mirego-maven/public') }
+    mavenLocal()
 }
 
 group 'com.mirego.trikot.http'
@@ -35,7 +36,7 @@ configurations.all {
 
 dependencies {
     api "com.mirego.trikot:streams:$trikot_streams_version"
-    api 'com.mirego.trikot:http:0.22.1'
+    api 'com.mirego.trikot:http:0.24.1-SNAPSHOT'
     implementation "io.ktor:ktor-client-android:$ktor_version"
     api "io.ktor:ktor-client-logging-jvm:$ktor_version"
     implementation 'androidx.lifecycle:lifecycle-extensions:2.1.0'
@@ -53,6 +54,16 @@ publishing {
     publications {
         mavenAar(MavenPublication) {
             from components.android
+        }
+    }
+}
+
+kotlin {
+    sourceSets {
+        all {
+            languageSettings {
+                useExperimentalAnnotation('kotlin.ExperimentalStdlibApi')
+            }
         }
     }
 }

--- a/android-ktx/build.gradle
+++ b/android-ktx/build.gradle
@@ -15,7 +15,6 @@ repositories {
     maven { url "https://kotlin.bintray.com/kotlinx" }
     maven { url 'https://jitpack.io' }
     maven { url('https://s3.amazonaws.com/mirego-maven/public') }
-    mavenLocal()
 }
 
 group 'com.mirego.trikot.http'

--- a/android-ktx/build.gradle
+++ b/android-ktx/build.gradle
@@ -36,7 +36,7 @@ configurations.all {
 
 dependencies {
     api "com.mirego.trikot:streams:$trikot_streams_version"
-    api 'com.mirego.trikot:http:0.24.1-SNAPSHOT'
+    api 'com.mirego.trikot:http:0.24.1'
     implementation "io.ktor:ktor-client-android:$ktor_version"
     api "io.ktor:ktor-client-logging-jvm:$ktor_version"
     implementation 'androidx.lifecycle:lifecycle-extensions:2.1.0'
@@ -54,16 +54,6 @@ publishing {
     publications {
         mavenAar(MavenPublication) {
             from components.android
-        }
-    }
-}
-
-kotlin {
-    sourceSets {
-        all {
-            languageSettings {
-                useExperimentalAnnotation('kotlin.ExperimentalStdlibApi')
-            }
         }
     }
 }

--- a/android-ktx/src/main/java/com/mirego/trikot/http/android/ktx/requestFactory/KtorHttpRequestFactory.kt
+++ b/android-ktx/src/main/java/com/mirego/trikot/http/android/ktx/requestFactory/KtorHttpRequestFactory.kt
@@ -17,7 +17,7 @@ import io.ktor.client.features.logging.Logging
 import io.ktor.client.request.header
 import io.ktor.client.request.request
 import io.ktor.client.request.url
-import io.ktor.client.response.readText
+import io.ktor.client.response.readBytes
 import io.ktor.content.ByteArrayContent
 import io.ktor.content.TextContent
 import io.ktor.http.ContentType
@@ -26,6 +26,7 @@ import io.ktor.util.flattenEntries
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.io.charsets.MalformedInputException
 import org.reactivestreams.Publisher
 import kotlin.coroutines.CoroutineContext
 
@@ -77,11 +78,11 @@ class KtorHttpRequestFactory(
                         method = requestBuilder.method.ktorMethod
                     }
 
-                    publisher.value = KTorHttpResponse(response, response.call.response.readText())
+                    publisher.value = KTorHttpResponse(response, response.call.response.readBytes())
                 } catch (ex: Exception) {
                     val response = (ex as? ResponseException)?.response
                     if (response != null) {
-                        publisher.value = KTorHttpResponse(response, response.call.response.readText())
+                        publisher.value = KTorHttpResponse(response, response.call.response.readBytes())
                     } else {
                         publisher.error = ex
                     }
@@ -92,9 +93,10 @@ class KtorHttpRequestFactory(
         }
     }
 
-    class KTorHttpResponse(response: io.ktor.client.response.HttpResponse, body: String?) : HttpResponse {
+    class KTorHttpResponse(response: io.ktor.client.response.HttpResponse, bytes: ByteArray?) : HttpResponse {
         override val statusCode: Int = response.status.value
-        override val bodyString: String? = body
+        override val bodyByteArray: ByteArray? = bytes
+        override val bodyString: String? get() = bodyByteArray?.decodeToString()
         override val headers: Map<String, String> = response.headers.flattenEntries().toMap()
         override val source: HttpResponse.ResponseSource = HttpResponse.ResponseSource.UNKNOWN
     }

--- a/android-ktx/src/main/java/com/mirego/trikot/http/android/ktx/requestFactory/KtorHttpRequestFactory.kt
+++ b/android-ktx/src/main/java/com/mirego/trikot/http/android/ktx/requestFactory/KtorHttpRequestFactory.kt
@@ -96,7 +96,6 @@ class KtorHttpRequestFactory(
     class KTorHttpResponse(response: io.ktor.client.response.HttpResponse, bytes: ByteArray?) : HttpResponse {
         override val statusCode: Int = response.status.value
         override val bodyByteArray: ByteArray? = bytes
-        override val bodyString: String? get() = bodyByteArray?.decodeToString()
         override val headers: Map<String, String> = response.headers.flattenEntries().toMap()
         override val source: HttpResponse.ResponseSource = HttpResponse.ResponseSource.UNKNOWN
     }

--- a/http/build.gradle
+++ b/http/build.gradle
@@ -44,6 +44,12 @@ kotlin {
         fromPreset(presets.tvosX64, 'tvosX64')
     }
     sourceSets {
+        all {
+            languageSettings {
+                useExperimentalAnnotation('kotlin.ExperimentalStdlibApi')
+            }
+        }
+
         commonMain {
             dependencies {
                 implementation "com.mirego.trikot:streams:$trikot_streams_version"
@@ -126,7 +132,7 @@ kotlin {
 }
 
 release {
-   checkTasks = ['check']
-   buildTasks = ['publish']
-   updateVersionPart = 1
+    checkTasks = ['check']
+    buildTasks = ['publish']
+    updateVersionPart = 1
 }

--- a/http/src/commonMain/kotlin/com/mirego/trikot/http/HttpConfiguration.kt
+++ b/http/src/commonMain/kotlin/com/mirego/trikot/http/HttpConfiguration.kt
@@ -1,24 +1,27 @@
 package com.mirego.trikot.http
 
-import com.mirego.trikot.http.connectivity.ConnectivityState
 import com.mirego.trikot.foundation.concurrent.AtomicReference
 import com.mirego.trikot.foundation.concurrent.dispatchQueue.DispatchQueue
 import com.mirego.trikot.foundation.concurrent.dispatchQueue.OperationDispatchQueue
 import com.mirego.trikot.foundation.concurrent.freeze
+import com.mirego.trikot.http.connectivity.ConnectivityState
+import com.mirego.trikot.http.header.DefaultHttpHeaderProvider
+import com.mirego.trikot.http.requestFactory.EmptyHttpRequestFactory
 import com.mirego.trikot.streams.reactive.Publishers
 import kotlinx.serialization.UnstableDefault
 import kotlinx.serialization.json.Json
 import org.reactivestreams.Publisher
-import com.mirego.trikot.http.header.DefaultHttpHeaderProvider
-import com.mirego.trikot.http.requestFactory.EmptyHttpRequestFactory
 
 object HttpConfiguration {
     private val internalHttpRequestFactory = AtomicReference<HttpRequestFactory>(
         EmptyHttpRequestFactory()
     )
-    private val internalNetworkDispatchQueue = AtomicReference<DispatchQueue>(OperationDispatchQueue())
-    private val internalDefaultHeaderProvider = AtomicReference<HttpHeaderProvider>(DefaultHttpHeaderProvider())
-    private val internalConnectivityStatePublisher = AtomicReference<Publisher<ConnectivityState>>(Publishers.behaviorSubject())
+    private val internalNetworkDispatchQueue =
+        AtomicReference<DispatchQueue>(OperationDispatchQueue())
+    private val internalDefaultHeaderProvider =
+        AtomicReference<HttpHeaderProvider>(DefaultHttpHeaderProvider())
+    private val internalConnectivityStatePublisher =
+        AtomicReference<Publisher<ConnectivityState>>(Publishers.behaviorSubject())
     private val internalBaseUrl = AtomicReference("")
 
     /**
@@ -62,7 +65,10 @@ object HttpConfiguration {
             return internalConnectivityStatePublisher.value
         }
         set(value) {
-            internalConnectivityStatePublisher.setOrThrow(internalConnectivityStatePublisher.value, value)
+            internalConnectivityStatePublisher.setOrThrow(
+                internalConnectivityStatePublisher.value,
+                value
+            )
         }
 
     /**
@@ -79,6 +85,6 @@ object HttpConfiguration {
     /**
      * Shared JSON parser used by DeserializableHttpRequestPublisher
      */
-    @UseExperimental(UnstableDefault::class)
+    @OptIn(UnstableDefault::class)
     val json = Json.nonstrict.also { freeze(it) }
 }

--- a/http/src/commonMain/kotlin/com/mirego/trikot/http/HttpResponse.kt
+++ b/http/src/commonMain/kotlin/com/mirego/trikot/http/HttpResponse.kt
@@ -6,11 +6,6 @@ interface HttpResponse {
      */
     val statusCode: Int
     /**
-     * Body result as String
-     * Note: In the future version, we should have a bodyStream (inputStream) instead of bodyString
-     */
-    val bodyString: String?
-    /**
      * Body result as ByteArray
      */
     val bodyByteArray: ByteArray?

--- a/http/src/commonMain/kotlin/com/mirego/trikot/http/HttpResponse.kt
+++ b/http/src/commonMain/kotlin/com/mirego/trikot/http/HttpResponse.kt
@@ -11,6 +11,10 @@ interface HttpResponse {
      */
     val bodyString: String?
     /**
+     * Body result as ByteArray
+     */
+    val bodyByteArray: ByteArray?
+    /**
      * Result header
      */
     val headers: Map<String, String>

--- a/http/src/commonMain/kotlin/com/mirego/trikot/http/HttpResponseExtensions.kt
+++ b/http/src/commonMain/kotlin/com/mirego/trikot/http/HttpResponseExtensions.kt
@@ -1,0 +1,4 @@
+package com.mirego.trikot.http
+
+val HttpResponse.bodyString: String?
+    get() = bodyByteArray?.decodeToString()

--- a/http/src/commonMain/kotlin/com/mirego/trikot/http/requestPublisher/DeserializableHttpRequestPublisher.kt
+++ b/http/src/commonMain/kotlin/com/mirego/trikot/http/requestPublisher/DeserializableHttpRequestPublisher.kt
@@ -5,16 +5,15 @@ import com.mirego.trikot.http.HttpHeaderProvider
 import com.mirego.trikot.http.HttpResponse
 import com.mirego.trikot.http.HttpResponseException
 import com.mirego.trikot.http.RequestBuilder
+import com.mirego.trikot.http.bodyString
 import kotlinx.serialization.DeserializationStrategy
-import kotlinx.serialization.UnstableDefault
 
 open class DeserializableHttpRequestPublisher<T>(
     private val deserializer: DeserializationStrategy<T>,
     override val builder: RequestBuilder,
     headerProvider: HttpHeaderProvider = HttpConfiguration.defaultHttpHeaderProvider
 ) : HttpRequestPublisher<T>(headerProvider = headerProvider) {
-
-    @UseExperimental(UnstableDefault::class)
+    
     override fun processResponse(response: HttpResponse): T {
         when (response.statusCode) {
             in 200..299 -> return successfulResponse(response)

--- a/swift-extensions/TrikotHttpResponse.swift
+++ b/swift-extensions/TrikotHttpResponse.swift
@@ -4,6 +4,8 @@ import TRIKOT_FRAMEWORK_NAME
 public class TrikotHttpResponse: NSObject, HttpResponse {
     public var bodyString: String?
 
+    public var bodyByteArray: KotlinByteArray?
+
     public var headers: [String: String]
 
     public var source: HttpResponseResponseSource
@@ -23,6 +25,7 @@ public class TrikotHttpResponse: NSObject, HttpResponse {
             statusCode = Int32(response.statusCode)
         }
         if let data = data {
+            bodyByteArray = ByteArrayNativeUtils().convert(data: data)
             bodyString = String(data: data, encoding: .utf8)
         }
 

--- a/swift-extensions/TrikotHttpResponse.swift
+++ b/swift-extensions/TrikotHttpResponse.swift
@@ -25,6 +25,8 @@ public class TrikotHttpResponse: NSObject, HttpResponse {
         }
         if let data = data, data.count > 0 {
             bodyByteArray = MrFreeze().freeze(objectToFreeze: ByteArrayNativeUtils().convert(data: data)) as? KotlinByteArray
+        } else {
+            bodyByteArray = KotlinByteArray(size: 0)
         }
 
         self.headers = headers

--- a/swift-extensions/TrikotHttpResponse.swift
+++ b/swift-extensions/TrikotHttpResponse.swift
@@ -2,7 +2,6 @@ import Foundation
 import TRIKOT_FRAMEWORK_NAME
 
 public class TrikotHttpResponse: NSObject, HttpResponse {
-    public var bodyString: String?
 
     public var bodyByteArray: KotlinByteArray?
 
@@ -24,9 +23,8 @@ public class TrikotHttpResponse: NSObject, HttpResponse {
             }
             statusCode = Int32(response.statusCode)
         }
-        if let data = data {
-            bodyByteArray = ByteArrayNativeUtils().convert(data: data)
-            bodyString = String(data: data, encoding: .utf8)
+        if let data = data, data.count > 0 {
+            bodyByteArray = MrFreeze().freeze(objectToFreeze: ByteArrayNativeUtils().convert(data: data)) as? KotlinByteArray
         }
 
         self.headers = headers


### PR DESCRIPTION
## Description
We needed to be able to access to byteArray of the httpResponse instead of only assuming the body would be a string.

## Motivation and Context
This allows us to handle downloading of images/files instead of only json string payloads

## How Has This Been Tested?
Tested in my application and made sure that bodyString was still available using an HttpResponse extension.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

** Also fixed some warnings and small formatting 
