### PR TITLE
Add some additional configurability to Trikot.http 

### DIFF
--- a/http/src/commonMain/kotlin/com/mirego/trikot/http/HttpConfiguration.kt
+++ b/http/src/commonMain/kotlin/com/mirego/trikot/http/HttpConfiguration.kt
@@ -3,19 +3,18 @@ package com.mirego.trikot.http
 import com.mirego.trikot.foundation.concurrent.AtomicReference
 import com.mirego.trikot.foundation.concurrent.dispatchQueue.DispatchQueue
 import com.mirego.trikot.foundation.concurrent.dispatchQueue.OperationDispatchQueue
-import com.mirego.trikot.foundation.concurrent.freeze
 import com.mirego.trikot.http.connectivity.ConnectivityState
 import com.mirego.trikot.http.header.DefaultHttpHeaderProvider
 import com.mirego.trikot.http.requestFactory.EmptyHttpRequestFactory
 import com.mirego.trikot.streams.reactive.Publishers
 import kotlinx.serialization.UnstableDefault
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonConfiguration
 import org.reactivestreams.Publisher
 
 object HttpConfiguration {
-    private val internalHttpRequestFactory = AtomicReference<HttpRequestFactory>(
-        EmptyHttpRequestFactory()
-    )
+    private val internalHttpRequestFactory =
+        AtomicReference<HttpRequestFactory>(EmptyHttpRequestFactory())
     private val internalNetworkDispatchQueue =
         AtomicReference<DispatchQueue>(OperationDispatchQueue())
     private val internalDefaultHeaderProvider =
@@ -23,6 +22,20 @@ object HttpConfiguration {
     private val internalConnectivityStatePublisher =
         AtomicReference<Publisher<ConnectivityState>>(Publishers.behaviorSubject())
     private val internalBaseUrl = AtomicReference("")
+    private val internalJson =
+        AtomicReference(defaultJsonConfiguration())
+
+    @OptIn(UnstableDefault::class)
+    private fun defaultJsonConfiguration(): Json {
+        return Json(
+            JsonConfiguration(
+                isLenient = true,
+                ignoreUnknownKeys = true,
+                serializeSpecialFloatingPointValues = true,
+                useArrayPolymorphism = true
+            )
+        )
+    }
 
     /**
      * Shared HTTPRequestFactory
@@ -85,6 +98,12 @@ object HttpConfiguration {
     /**
      * Shared JSON parser used by DeserializableHttpRequestPublisher
      */
-    @OptIn(UnstableDefault::class)
-    val json = Json.nonstrict.also { freeze(it) }
+
+    var json: Json
+        get() {
+            return internalJson.value
+        }
+        set(value) {
+            internalJson.setOrThrow(internalJson.value, value)
+        }
 }


### PR DESCRIPTION
## Description
This PR adds the possibility of customizing 2 additional things. 
1. In the multi-platform code, we can now provide a custom `Json` instance for request deserialization
2. In the android-ktx code, we can now provide a custom HttpClient to the KtorHttpRequestFactory

## Motivation and Context
For `Json`, simply to be able to configure the parsing based on the projet requirements, in particular to specify a custom serialModule to support polymorphism

For KtorHttpRequestFactory, to allow using a different engine. By default, the Android engine is used and this engine does not use any caching. With this modification, you can use for example then OkHttp engine and add a disk cache.

## How Has This Been Tested?
Tested in my projet. I made sure the  parsing still works for Json and made sure request still fire + the passed in logging configuration is still used

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
