### PR TITLE
Fix URL not constructed using builder

### DIFF
--- a/android-ktx/src/main/java/com/mirego/trikot/http/android/ktx/requestFactory/KtorHttpRequestFactory.kt
+++ b/android-ktx/src/main/java/com/mirego/trikot/http/android/ktx/requestFactory/KtorHttpRequestFactory.kt
@@ -16,6 +16,7 @@ import io.ktor.client.features.logging.Logger
 import io.ktor.client.features.logging.Logging
 import io.ktor.client.request.header
 import io.ktor.client.request.request
+import io.ktor.client.request.url
 import io.ktor.client.statement.HttpStatement
 import io.ktor.client.statement.readBytes
 import io.ktor.content.ByteArrayContent
@@ -59,7 +60,7 @@ class KtorHttpRequestFactory(
             launch {
                 try {
                     httpClient.request<HttpStatement> {
-                        url { (requestBuilder.baseUrl ?: "") + (requestBuilder.path ?: "") }
+                        url((requestBuilder.baseUrl ?: "") + (requestBuilder.path ?: ""))
 
                         requestBuilder.headers.filter { it.key != com.mirego.trikot.http.ContentType }
                             .forEach { entry ->


### PR DESCRIPTION
## Description
Revert the `HttpRequestBuilder` url construction using a string instead of a UrlBuilder block.

## Motivation and Context
Returning a string in the url builder block has simply no effect at all and all requests resolves to `localhost`.

## How Has This Been Tested?
Tested in previous releases using the exact same code.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
