### PR TITLE
Mark TrikotHttpRequestFactory as open so it can be subclassed

### DIFF
--- a/swift-extensions/TrikotHttpRequestFactory.swift
+++ b/swift-extensions/TrikotHttpRequestFactory.swift
@@ -1,7 +1,7 @@
 import Foundation
 import TRIKOT_FRAMEWORK_NAME
 
-public class TrikotHttpRequestFactory: NSObject, HttpRequestFactory {
+open class TrikotHttpRequestFactory: NSObject, HttpRequestFactory {
     private let httpLogLevel: TrikotHttpLogLevel
 
     public init(httpLogLevel: TrikotHttpLogLevel = .none) {
@@ -9,7 +9,7 @@ public class TrikotHttpRequestFactory: NSObject, HttpRequestFactory {
         super.init()
     }
 
-    public func request(requestBuilder: RequestBuilder) -> HttpRequest {
+    open func request(requestBuilder: RequestBuilder) -> HttpRequest {
         return TrikotHttpRequest(requestBuilder, httpLogLevel: httpLogLevel)
     }
 }


### PR DESCRIPTION
## Description
Currently not possible to provide a subclass of `TrikotHttpRequestFactory` tailored to an app specific requirements since the class and it's sole public method `func request(requestBuilder: RequestBuilder) -> HttpRequest` where not marked open. 

## Motivation and Context
Needed to be able to return different implementations of HttpRequest depending on the context.
Actual requirements motivating this change: Using a custom HttpRequest that always uses the Cellular Network

## How Has This Been Tested?
Not really a code change since it only opens up the class to subclassing so no testing done aside from confirming that it is the required change to allow subclassing and overriding of `func request(requestBuilder: RequestBuilder) -> HttpRequest`

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
