### PR TITLE
Expose TrikotHttpResponse init method to objc

### DIFF
--- a/swift-extensions/TrikotHttpResponse.swift
+++ b/swift-extensions/TrikotHttpResponse.swift
@@ -11,7 +11,8 @@ public class TrikotHttpResponse: NSObject, HttpResponse {
 
     public var statusCode: Int32 = 0
 
-    init(data: Data?, response: URLResponse?) {
+    @objc
+    public init(data: Data?, response: URLResponse?) {
         var headers = [String: String]()
         source = HttpResponseResponseSource.unknown
         if let response = response as? HTTPURLResponse {


### PR DESCRIPTION
## Description
Simply making the init method of TrikotHttpResponse public and tagging it @objc so it can be created from objc code and from other modules

## Motivation and Context
Needed to implement a custom httpRequestFactory using low level C code

## How Has This Been Tested?
Not really a code since it only changes the visibility of a method. Made sure that this is the required change

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
