### PR TITLE
Added an HttpRequestPublisher implementation that returns the HttpResponse object (no parsing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,11 @@ To deserialize a JSON payload:
 - Create a kotlix.serializable class
 - Create a DeserializableHttpRequestPublisher with the serializer in parameter.
 
-## DeserializableHttpRequestPublisher
+## NoResponseHttpRequestPublisher
 If there is no need to parse the body of the response, use this publisher instead. Only errors will be handled.
+
+## ResponseHttpRequestPublisher
+If you want the raw HttpResponse object, use this publisher.
 
 ```kotlin
 @Serializable

--- a/http/src/commonMain/kotlin/com/mirego/trikot/http/requestPublisher/ResponseHttpRequestPublisher.kt
+++ b/http/src/commonMain/kotlin/com/mirego/trikot/http/requestPublisher/ResponseHttpRequestPublisher.kt
@@ -1,0 +1,22 @@
+package com.mirego.trikot.http.requestPublisher
+
+import com.mirego.trikot.http.HttpConfiguration
+import com.mirego.trikot.http.HttpHeaderProvider
+import com.mirego.trikot.http.HttpRequestFactory
+import com.mirego.trikot.http.HttpResponse
+import com.mirego.trikot.http.HttpResponseException
+import com.mirego.trikot.http.RequestBuilder
+
+open class ResponseHttpRequestPublisher(
+    override val builder: RequestBuilder,
+    headerProvider: HttpHeaderProvider = HttpConfiguration.defaultHttpHeaderProvider,
+    httpRequestFactory: HttpRequestFactory = HttpConfiguration.httpRequestFactory
+) : HttpRequestPublisher<HttpResponse>(headerProvider = headerProvider, httpRequestFactory = httpRequestFactory) {
+
+    override fun processResponse(response: HttpResponse): HttpResponse {
+        when (response.statusCode) {
+            in 200..299 -> return response
+            else -> throw HttpResponseException(response)
+        }
+    }
+}


### PR DESCRIPTION
## Description
There are cases where you may want to get the actual HttpResponse object in return. Added a class for that.

## Motivation and Context
This need arose in a project

## How Has This Been Tested?
This implementation is being use in a project

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
