### PR TITLE
Update Kotlin version to 1.4.20

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,11 @@
 kotlin.code.style=official
-kotlin_version=1.4.0
+kotlin_version=1.4.20
 kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.native.enableDependencyPropagation=false
-trikot_foundation_version=1.0.0
-trikot_streams_version=1.0.0
-ktor_version=1.4.0
-serialization_version=1.0.0-RC
+trikot_foundation_version=1.0.21
+trikot_streams_version=1.0.6
+ktor_version=1.4.1
+serialization_version=1.0.1
 android.useAndroidX=true
 android.enableJetifier=true
 kapt.incremental.apt=true

--- a/http/build.gradle
+++ b/http/build.gradle
@@ -51,7 +51,7 @@ kotlin {
             dependencies {
                 implementation "com.mirego.trikot:streams:$trikot_streams_version"
                 implementation "com.mirego.trikot:trikotFoundation:$trikot_foundation_version"
-                implementation "org.jetbrains.kotlinx:kotlinx-serialization-core:$serialization_version"
+                implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:$serialization_version"
             }
         }
 


### PR DESCRIPTION
Update Kotlin version to 1.4.20

## Description
Update Kotlin to `1.4.20` and bump dependencies version numbers to compatible versions using the same version of Kotlin.

## Motivation and Context
Keep it up to date

## How Has This Been Tested?
No code change, untested.

## Types of changes
- [x] Update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
