### PR TITLE
Excluded transitive dependencies on "org.reactivestreams" to avoid duplicate classes on Android

### DIFF
--- a/http/build.gradle.kts
+++ b/http/build.gradle.kts
@@ -77,7 +77,9 @@ kotlin {
                 api("io.ktor:ktor-client-logging-jvm:${project.extra["ktor_version"]}")
                 implementation("io.ktor:ktor-client-android:${project.extra["ktor_version"]}")
                 implementation("androidx.lifecycle:lifecycle-extensions:2.2.0")
-                implementation("androidx.lifecycle:lifecycle-reactivestreams-ktx:2.3.0")
+                implementation("androidx.lifecycle:lifecycle-reactivestreams-ktx:2.3.0") {
+                    exclude(group = "org.reactivestreams")
+                }
             }
         }
 


### PR DESCRIPTION
## Description
During the merge of android-ktx and main component, the exclusion of the transitive dependency on "org:reactivestreams" was lost. This resulted in build errors caused by the reactivestreams classes being included twice. (the Trikot ones and the "real" ones).

## Motivation and Context
Build errors.

## How Has This Been Tested?
In a a project using 2.0.0.

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
