### PR TITLE
Add missing freeze on empty body causing "not frozen" crash

### DIFF
--- a/swift-extensions/TrikotHttpResponse.swift
+++ b/swift-extensions/TrikotHttpResponse.swift
@@ -27,7 +27,7 @@ public class TrikotHttpResponse: NSObject, HttpResponse {
         if let data = data, data.count > 0 {
             bodyByteArray = MrFreeze().freeze(objectToFreeze: ByteArrayNativeUtils().convert(data: data)) as? KotlinByteArray
         } else {
-            bodyByteArray = KotlinByteArray(size: 0)
+            bodyByteArray = MrFreeze().freeze(objectToFreeze: KotlinByteArray(size: 0)) as? KotlinByteArray
         }
 
         self.headers = headers


### PR DESCRIPTION
## Description
When receiving an empty http response body, we did not freeze the zero length placeholder bytearray that was created on the fly, causing unwanted crashes

## How Has This Been Tested?
Since we do not have any tests on swift-extensions, I tested the fix in my own application. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
