### PR TITLE
Added optional parameters to the KtorHttpRequestFactory to specify timeout values.

### DIFF
--- a/http/src/androidMain/kotlin/com/mirego/trikot/http/android/requestFactory/KtorHttpRequestFactory.kt
+++ b/http/src/androidMain/kotlin/com/mirego/trikot/http/android/requestFactory/KtorHttpRequestFactory.kt
@@ -30,16 +30,21 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.reactivestreams.Publisher
 import kotlin.coroutines.CoroutineContext
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
+import kotlin.time.seconds
 
-private const val DEFAULT_TIMEOUT_MS = 10000L
+@ExperimentalTime
+private val DEFAULT_TIMEOUT_DURATION = 10.seconds
 
+@ExperimentalTime
 class KtorHttpRequestFactory(
     httpLogLevel: LogLevel = LogLevel.NONE,
     httpLogger: Logger = Logger.DEFAULT,
     private var httpClient: HttpClient = HttpClient(),
-    requestTimeoutMs: Long = DEFAULT_TIMEOUT_MS,
-    socketTimeoutMs: Long = requestTimeoutMs,
-    connectTimeoutMs: Long = requestTimeoutMs
+    requestTimeoutDuration: Duration = DEFAULT_TIMEOUT_DURATION,
+    socketTimeoutDuration: Duration = requestTimeoutDuration,
+    connectTimeoutDuration: Duration = requestTimeoutDuration
 ) : HttpRequestFactory {
     init {
         httpClient = httpClient.config {
@@ -48,9 +53,9 @@ class KtorHttpRequestFactory(
                 level = httpLogLevel
             }
             install(HttpTimeout) {
-                requestTimeoutMillis = requestTimeoutMs
-                socketTimeoutMillis = socketTimeoutMs
-                connectTimeoutMillis = connectTimeoutMs
+                requestTimeoutMillis = requestTimeoutDuration.toLongMilliseconds()
+                socketTimeoutMillis = socketTimeoutDuration.toLongMilliseconds()
+                connectTimeoutMillis = connectTimeoutDuration.toLongMilliseconds()
             }
         }
     }

--- a/http/src/androidMain/kotlin/com/mirego/trikot/http/android/requestFactory/KtorHttpRequestFactory.kt
+++ b/http/src/androidMain/kotlin/com/mirego/trikot/http/android/requestFactory/KtorHttpRequestFactory.kt
@@ -25,11 +25,11 @@ import io.ktor.content.TextContent
 import io.ktor.http.ContentType
 import io.ktor.http.HttpMethod
 import io.ktor.util.flattenEntries
-import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.reactivestreams.Publisher
+import kotlin.coroutines.CoroutineContext
 
 private const val DEFAULT_TIMEOUT_MS = 10000L
 

--- a/http/src/androidMain/kotlin/com/mirego/trikot/http/android/requestFactory/KtorHttpRequestFactory.kt
+++ b/http/src/androidMain/kotlin/com/mirego/trikot/http/android/requestFactory/KtorHttpRequestFactory.kt
@@ -9,6 +9,7 @@ import com.mirego.trikot.http.RequestBuilder
 import com.mirego.trikot.streams.cancellable.CancellableManager
 import com.mirego.trikot.streams.reactive.Publishers
 import io.ktor.client.HttpClient
+import io.ktor.client.features.HttpTimeout
 import io.ktor.client.features.ResponseException
 import io.ktor.client.features.logging.DEFAULT
 import io.ktor.client.features.logging.LogLevel
@@ -24,22 +25,32 @@ import io.ktor.content.TextContent
 import io.ktor.http.ContentType
 import io.ktor.http.HttpMethod
 import io.ktor.util.flattenEntries
+import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.reactivestreams.Publisher
-import kotlin.coroutines.CoroutineContext
+
+private const val DEFAULT_TIMEOUT_MS = 10000L
 
 class KtorHttpRequestFactory(
     httpLogLevel: LogLevel = LogLevel.NONE,
     httpLogger: Logger = Logger.DEFAULT,
-    private var httpClient: HttpClient = HttpClient()
+    private var httpClient: HttpClient = HttpClient(),
+    requestTimeoutMs: Long = DEFAULT_TIMEOUT_MS,
+    socketTimeoutMs: Long = requestTimeoutMs,
+    connectTimeoutMs: Long = requestTimeoutMs
 ) : HttpRequestFactory {
     init {
         httpClient = httpClient.config {
             install(Logging) {
                 logger = httpLogger
                 level = httpLogLevel
+            }
+            install(HttpTimeout) {
+                requestTimeoutMillis = requestTimeoutMs
+                socketTimeoutMillis = socketTimeoutMs
+                connectTimeoutMillis = connectTimeoutMs
             }
         }
     }


### PR DESCRIPTION
There is currently no straightforward way to specify HTTP timeout values. It was possible by passing the HttpClient() and configuring it outside of the factory constructor, but it would be convenient to have a more "exposed" interface.

3 new optional parameters have been added to the factory to specify the timeout values.

If not set, a default value of **10 seconds** will be used.

## Motivation and Context
By default Ktor have an almost infinite timeout delay (100 seconds it seems), which is not acceptable for most of the use cases. Giving the ability to set this timeout delay AND providing a more realistic default will ease usage.

## How Has This Been Tested?
In a project

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

⚠️ Note that if a project relied on the infinite nature of the current HTTP implementation, new timeout could occur. Please make sure that the new default value makes sense in your project, and specify another value if not.
