### PR TITLE
Update Kotlin to version 1.5.10 and add watchOS and macOS targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the library will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.2.0
+> 2021-06-08
+- Added watchOS and macOS targets
+- Updated Kotlin version to 1.5.10
+- Replace deprecated calls
+
 ## 2.1.0
 > 2021-05-10
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:4.1.2")
+        classpath("com.android.tools.build:gradle:4.1.3")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${project.extra["kotlin_version"]}")
         classpath("org.jetbrains.kotlin:kotlin-serialization:${project.extra["kotlin_version"]}")
         classpath("org.jlleitschuh.gradle:ktlint-gradle:9.4.1")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,12 @@
 kotlin.code.style=official
-kotlin_version=1.5.0
+kotlin_version=1.5.10
 kotlin.mpp.stability.nowarn=true
 kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.native.enableDependencyPropagation=false
-trikot_foundation_version=2.1.0
-trikot_streams_version=2.1.0
-ktor_version=1.5.4
-serialization_version=1.0.1
+trikot_foundation_version=2.2.0
+trikot_streams_version=2.2.0
+ktor_version=1.6.0
+serialization_version=1.2.1
 android.useAndroidX=true
 android.enableJetifier=true
 kapt.incremental.apt=true

--- a/http/build.gradle.kts
+++ b/http/build.gradle.kts
@@ -26,6 +26,8 @@ kotlin {
     ios()
     iosArm32("iosArm32")
     tvos()
+    watchos()
+    macosX64()
     js(IR) {
         moduleName = "@trikot/http"
         browser()
@@ -104,6 +106,22 @@ kotlin {
         }
 
         val tvosX64Main by getting {
+            dependsOn(nativeMain)
+        }
+
+        val watchos32Main by creating {
+            dependsOn(nativeMain)
+        }
+
+        val watchosArm64Main by getting {
+            dependsOn(nativeMain)
+        }
+
+        val watchosX64Main by getting {
+            dependsOn(nativeMain)
+        }
+
+        val macosX64Main by getting {
             dependsOn(nativeMain)
         }
     }

--- a/http/gradle.properties
+++ b/http/gradle.properties
@@ -1,2 +1,2 @@
 #Mon May 10 16:25:04 EDT 2021
-version=2.1.1-SNAPSHOT
+version=2.2.0-SNAPSHOT

--- a/http/src/androidMain/kotlin/com/mirego/trikot/http/android/requestFactory/KtorHttpRequestFactory.kt
+++ b/http/src/androidMain/kotlin/com/mirego/trikot/http/android/requestFactory/KtorHttpRequestFactory.kt
@@ -32,10 +32,9 @@ import org.reactivestreams.Publisher
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
-import kotlin.time.seconds
 
 @ExperimentalTime
-private val DEFAULT_TIMEOUT_DURATION = 10.seconds
+private val DEFAULT_TIMEOUT_DURATION = Duration.seconds(10)
 
 @ExperimentalTime
 class KtorHttpRequestFactory(
@@ -53,9 +52,9 @@ class KtorHttpRequestFactory(
                 level = httpLogLevel
             }
             install(HttpTimeout) {
-                requestTimeoutMillis = requestTimeoutDuration.toLongMilliseconds()
-                socketTimeoutMillis = socketTimeoutDuration.toLongMilliseconds()
-                connectTimeoutMillis = connectTimeoutDuration.toLongMilliseconds()
+                requestTimeoutMillis = requestTimeoutDuration.inWholeMilliseconds
+                socketTimeoutMillis = socketTimeoutDuration.inWholeMilliseconds
+                connectTimeoutMillis = connectTimeoutDuration.inWholeMilliseconds
             }
             expectSuccess = false
         }


### PR DESCRIPTION
## 📖 Description
- Added watchOS and macOS targets
- Updated Kotlin version to 1.5.10
- Replace deprecated calls

## 💭 Motivation and Context
macOS target was needed for a project

## 🧪 How Has This Been Tested?
`./gradlew build`

## 🦀 Dispatch
`#dispatch/kmp`
