### PR TITLE
Add UNDEFINED to ConnectivityState

### DIFF
--- a/http/src/commonMain/kotlin/com/mirego/trikot/http/connectivity/ConnectivityState.kt
+++ b/http/src/commonMain/kotlin/com/mirego/trikot/http/connectivity/ConnectivityState.kt
@@ -3,5 +3,6 @@ package com.mirego.trikot.http.connectivity
 enum class ConnectivityState {
     WIFI,
     CELLULAR,
-    NONE
+    NONE,
+    UNDEFINED
 }

--- a/swift-extensions/TrikotConnectivityService.swift
+++ b/swift-extensions/TrikotConnectivityService.swift
@@ -4,7 +4,7 @@ import TRIKOT_FRAMEWORK_NAME
 
 public class TrikotConnectivityService {
     public static let shared = TrikotConnectivityService()
-    public let publisher = Publishers().behaviorSubject(value: nil)
+    public let publisher = Publishers().behaviorSubject(value: ConnectivityState.undefined)
 
     let reachability = try! Reachability()
 
@@ -25,7 +25,7 @@ public class TrikotConnectivityService {
         do {
             try reachability.startNotifier()
         } catch {
-            publisher.value = ConnectivityState.none
+            publisher.value = ConnectivityState.undefined
             print("Unable to start reachability notifier")
         }
     }


### PR DESCRIPTION
Add UNDEFINED to ConnectivityState

## Description
In order to avoid that TrikotConnectivityService publisher initial value is nil, we introduce the concept of `undefined` until the connectivity state is returned by the `Reachability` service

It it not actually needed on Android side as the connectivityState is not async

## Motivation and Context
The motivation is to avoid publishing a nil value

## How Has This Been Tested?
This was tested by integrating the current branch in the Podfile and by using the snapshot in the common. Then the change was tested by changing the connectivity state. There's no real big impact and it's not a breaking change

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
