### PR TITLE
Updated Kotlin version to 1.5.31 and trikot dependancies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the library will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+# 2.2.2
+> 2021-10-18
+- Updated Kotlin version to 1.5.31
+- Updated `trikot.foundation` version to 2.2.2
+- Updated `trikot.streams` version to 2.2.5
+
 ## 2.2.1
 > 2021-10-12
 - Integrate custom timeout for specific requests through `RequestBuilder` 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,6 @@ repositories {
 allprojects {
     repositories {
         google()
-        maven("https://kotlin.bintray.com/kotlinx")
+        mavenCentral()
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
 kotlin.code.style=official
-kotlin_version=1.5.10
+kotlin_version=1.5.31
 kotlin.mpp.stability.nowarn=true
 kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.native.enableDependencyPropagation=false
-trikot_foundation_version=2.2.0
-trikot_streams_version=2.2.0
+trikot_foundation_version=2.2.2
+trikot_streams_version=2.2.5
 ktor_version=1.6.0
 serialization_version=1.2.1
 android.useAndroidX=true

--- a/http/build.gradle.kts
+++ b/http/build.gradle.kts
@@ -10,7 +10,6 @@ repositories {
     google()
     mavenLocal()
     mavenCentral()
-    maven("https://kotlin.bintray.com/kotlinx")
     maven("https://jitpack.io")
     maven("https://plugins.gradle.org/m2/")
     maven("https://s3.amazonaws.com/mirego-maven/public")


### PR DESCRIPTION
## Description
Following the updates made to `trikot.foundation`, we update this library by updating Kotlin to 1.5.31, Foundation to 2.2.2 and Streams to 2.2.5.

## How Has This Been Tested?
This new version has been build in a custom project

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
