### PR TITLE
Fix silenced exceptions when dispatching http request success result

### DIFF
--- a/http/build.gradle.kts
+++ b/http/build.gradle.kts
@@ -35,7 +35,7 @@ kotlin {
 
     sourceSets {
         all {
-            languageSettings.useExperimentalAnnotation("kotlin.ExperimentalStdlibApi")
+            languageSettings.optIn("kotlin.ExperimentalStdlibApi")
         }
 
         val commonMain by getting {

--- a/http/src/commonMain/kotlin/com/mirego/trikot/http/requestPublisher/HttpRequestPublisher.kt
+++ b/http/src/commonMain/kotlin/com/mirego/trikot/http/requestPublisher/HttpRequestPublisher.kt
@@ -37,13 +37,15 @@ abstract class HttpRequestPublisher<T>(
 
                 executeRequest(cancellableManager, requestBuilder).subscribe(
                     cancellableManager,
-                    onNext = {
+                    onNext = { response ->
                         operationQueue.dispatch {
-                            try {
-                                dispatchSuccess(processResponse(it))
+                            val result = try {
+                                processResponse(response)
                             } catch (e: Exception) {
                                 dispatchError(e)
+                                return@dispatch
                             }
+                            dispatchSuccess(result)
                         }
                     },
                     onError = { sourceError ->


### PR DESCRIPTION
## Description
The try catch was surrounding the whole PublishSubjectImpl's value dispatch flow instead of simply wrapping the response's processing. This was causing execution interruptions when an exception would occur on the same run loop deeper in the reactive chain following the http request's success.

The try catch scope has now been reduced to the response processing only, allowing for further exceptions to be properly raised.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
