### PR TITLE
Add encoded parameters to RequestBuilder

### DIFF
--- a/http/build.gradle.kts
+++ b/http/build.gradle.kts
@@ -43,6 +43,7 @@ kotlin {
                 implementation("com.mirego.trikot:trikotFoundation:${project.extra["trikot_foundation_version"]}")
                 implementation("com.mirego.trikot:streams:${project.extra["trikot_streams_version"]}")
                 implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:${project.extra["serialization_version"]}")
+                implementation("io.ktor:ktor-http:${project.extra["ktor_version"]}")
             }
         }
 
@@ -50,6 +51,11 @@ kotlin {
             dependencies {
                 implementation("org.jetbrains.kotlin:kotlin-test-common")
                 implementation("org.jetbrains.kotlin:kotlin-test-annotations-common")
+                implementation("org.jetbrains.kotlin:kotlin-test")
+                implementation("org.jetbrains.kotlin:kotlin-test-junit")
+                implementation("org.jetbrains.kotlin:kotlin-reflect")
+                implementation("junit:junit:4.13.2")
+                implementation("io.mockk:mockk-common:1.12.1")
             }
         }
 

--- a/http/src/androidMain/kotlin/com/mirego/trikot/http/android/requestFactory/KtorHttpRequestFactory.kt
+++ b/http/src/androidMain/kotlin/com/mirego/trikot/http/android/requestFactory/KtorHttpRequestFactory.kt
@@ -84,7 +84,7 @@ class KtorHttpRequestFactory(
             launch {
                 try {
                     httpClient.request<HttpStatement> {
-                        url((requestBuilder.baseUrl ?: "") + (requestBuilder.path ?: ""))
+                        url(requestBuilder.buildUrl())
 
                         requestBuilder.headers.filter { it.key != com.mirego.trikot.http.ContentType }
                             .forEach { entry ->

--- a/http/src/commonMain/kotlin/com/mirego/trikot/http/RequestBuilder.kt
+++ b/http/src/commonMain/kotlin/com/mirego/trikot/http/RequestBuilder.kt
@@ -1,39 +1,90 @@
 package com.mirego.trikot.http
 
+import io.ktor.http.Parameters
+import io.ktor.http.ParametersBuilder
+import io.ktor.http.formUrlEncode
+
 class RequestBuilder {
     /**
      * Base path
      * ex: http://www.mysite.com/api
      */
     var baseUrl: String? = null
+
     /**
      * Path to append to the base Path
      * ex: /users/1
      */
     var path: String? = null
+
     /**
      * HttpMethod
      */
     var method = HttpMethod.GET
+
     /**
      * Headers to send the request with. Will be merged with the headers provided by the HttpHeaderProvider.
      */
     var headers: Map<String, String> = HashMap()
+
     /**
      * Body to send the request with. Only String are supported for now.
      */
     var body: Any? = null
+
     /**
      * Unsupported
      */
     var cachePolicy: CachePolicy = CachePolicy.USE_PROTOCOL_CACHE_POLICY
+
     /**
      * Timeout (in seconds) that needs to be applied to this specific request.
      * If null, the default configured timeout will be used
      */
     var timeout: Int? = null
+
     /**
      * Unsupported
      */
     var followRedirects: Boolean = true
+
+    /**
+     * Url query parameters
+     */
+    var parameters: Map<String, String> = HashMap()
+
+    /**
+     * Build the request Url using base url, path and parameters
+     *
+     * Parameters are encoded by default
+     */
+    fun buildUrl(): String {
+        return (baseUrl ?: "") + buildPath()
+    }
+
+    private fun buildPath(): String {
+        val queryParameters = buildParameters()
+
+        return (path ?: "") + (
+            when (queryParameters) {
+                null -> ""
+                else -> {
+                    val prefix = when (path?.contains("?")) { true -> "&" else -> "?" }
+                    "$prefix${queryParameters.formUrlEncode()}"
+                }
+            })
+    }
+
+    private fun buildParameters(): Parameters? {
+        return when (parameters.isEmpty()) {
+            true -> null
+            else -> ParametersBuilder()
+                .also { builder ->
+                    parameters.forEach {
+                        builder.append(it.key, it.value)
+                    }
+                }
+                .build()
+        }
+    }
 }

--- a/http/src/commonMain/kotlin/com/mirego/trikot/http/RequestBuilder.kt
+++ b/http/src/commonMain/kotlin/com/mirego/trikot/http/RequestBuilder.kt
@@ -69,10 +69,14 @@ class RequestBuilder {
             when (queryParameters) {
                 null -> ""
                 else -> {
-                    val prefix = when (path?.contains("?")) { true -> "&" else -> "?" }
+                    val prefix = when (path?.contains("?")) {
+                        true -> "&"
+                        else -> "?"
+                    }
                     "$prefix${queryParameters.formUrlEncode()}"
                 }
-            })
+            }
+            )
     }
 
     private fun buildParameters(): Parameters? {

--- a/http/src/commonMain/kotlin/com/mirego/trikot/http/requestPublisher/HttpRequestPublisher.kt
+++ b/http/src/commonMain/kotlin/com/mirego/trikot/http/requestPublisher/HttpRequestPublisher.kt
@@ -87,6 +87,7 @@ abstract class HttpRequestPublisher<T>(
             it.headers = builder.headers + headers
             it.method = builder.method
             it.timeout = builder.timeout
+            it.parameters = builder.parameters
         }
     }
 }

--- a/http/src/commonTest/kotlin/com/mirego/trikot/http/RequestBuilderTest.kt
+++ b/http/src/commonTest/kotlin/com/mirego/trikot/http/RequestBuilderTest.kt
@@ -22,7 +22,7 @@ class RequestBuilderTest {
     }
 
     @Test
-    fun `given empty path when buildUrl then return base url`() {
+    fun testGivenEmptyPathWhenBuildUrlThenReturnBaseUrl() {
 
         val requestBuilder = RequestBuilder().also {
             it.baseUrl = BASE_URL
@@ -32,14 +32,24 @@ class RequestBuilderTest {
     }
 
     @Test
-    fun `given empty baseUrl and path when buildUrl then return empty string`() {
+    fun testGivenEmptyBaseUrlWhenBuildUrlThenReturnPath() {
+
+        val requestBuilder = RequestBuilder().also {
+            it.path = PATH
+        }
+
+        assertEquals(PATH, requestBuilder.buildUrl())
+    }
+
+    @Test
+    fun testGivenEmptyPathAndUrlWhenBuildUrlThenReturnEmptyString() {
         val requestBuilder = RequestBuilder()
 
         assertEquals("", requestBuilder.buildUrl())
     }
 
     @Test
-    fun `given parameters when buildUrl then return url with encoded parameters`() {
+    fun testGivenParametersWhenBuildUrlThenReturnUrlWithEncodedParameters() {
         val requestBuilder = RequestBuilder().also {
             it.baseUrl = BASE_URL
             it.path = PATH
@@ -57,7 +67,7 @@ class RequestBuilderTest {
     }
 
     @Test
-    fun `given path already contains parameters when buildUrl then return url with additional parameters encoded`() {
+    fun testGivenPathAlreadyContainsParametersWhenBuildUrlThenReturnUrlWithAdditionalParametersEncoded() {
         val requestBuilder = RequestBuilder().also {
             it.baseUrl = BASE_URL
             it.path = "$PATH?foo=bar"

--- a/http/src/commonTest/kotlin/com/mirego/trikot/http/RequestBuilderTest.kt
+++ b/http/src/commonTest/kotlin/com/mirego/trikot/http/RequestBuilderTest.kt
@@ -1,0 +1,71 @@
+package com.mirego.trikot.http
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RequestBuilderTest {
+
+    companion object {
+        val BASE_URL = "https://www.url.com"
+        val PATH = "/api"
+    }
+
+    @Test
+    fun testBuildUrl() {
+
+        val requestBuilder = RequestBuilder().also {
+            it.baseUrl = BASE_URL
+            it.path = PATH
+        }
+
+        assertEquals("https://www.url.com/api", requestBuilder.buildUrl())
+    }
+
+    @Test
+    fun `given empty path when buildUrl then return base url`() {
+
+        val requestBuilder = RequestBuilder().also {
+            it.baseUrl = BASE_URL
+        }
+
+        assertEquals(BASE_URL, requestBuilder.buildUrl())
+    }
+
+    @Test
+    fun `given empty baseUrl and path when buildUrl then return empty string`() {
+        val requestBuilder = RequestBuilder()
+
+        assertEquals("", requestBuilder.buildUrl())
+    }
+
+    @Test
+    fun `given parameters when buildUrl then return url with encoded parameters`() {
+        val requestBuilder = RequestBuilder().also {
+            it.baseUrl = BASE_URL
+            it.path = PATH
+            it.parameters = mapOf(
+                "param" to "value1",
+                "paramWithSpace" to "value ABC",
+                "jsonParam" to "{\"data\": [\"value1\",\"value2\",\"value3\"]}",
+            )
+        }
+
+        assertEquals(
+            "https://www.url.com/api?param=value1&paramWithSpace=value+ABC&jsonParam=%7B%22data%22%3A+%5B%22value1%22%2C%22value2%22%2C%22value3%22%5D%7D",
+            requestBuilder.buildUrl()
+        )
+    }
+
+    @Test
+    fun `given path already contains parameters when buildUrl then return url with additional parameters encoded`() {
+        val requestBuilder = RequestBuilder().also {
+            it.baseUrl = BASE_URL
+            it.path = "$PATH?foo=bar"
+            it.parameters = mapOf(
+                "param" to "value 1"
+            )
+        }
+
+        assertEquals("https://www.url.com/api?foo=bar&param=value+1", requestBuilder.buildUrl())
+    }
+}

--- a/http/src/jsMain/kotlin/com.mirego.trikot.http/web/WebHttpRequest.kt
+++ b/http/src/jsMain/kotlin/com.mirego.trikot.http/web/WebHttpRequest.kt
@@ -22,7 +22,7 @@ class WebHttpRequest(
         try {
             val xhr = XMLHttpRequest()
             val method = requestBuilder.method.toString()
-            val url = (requestBuilder.baseUrl ?: "") + (requestBuilder.path ?: "")
+            val url = requestBuilder.buildUrl()
             val timeout = (requestBuilder.timeout ?: DEFAULT_TIMEOUT_IN_SECONDS) * 1000
 
             xhr.open(method, url, true)

--- a/swift-extensions/TrikotHttpRequest.swift
+++ b/swift-extensions/TrikotHttpRequest.swift
@@ -18,7 +18,7 @@ public class TrikotHttpRequest: NSObject, HttpRequest {
     public func execute(cancellableManager: CancellableManager) -> Publisher {
         let resultPublisher = Publishers().frozenBehaviorSubject(value: nil)
 
-        if let url = URL(string: (requestBuilder.baseUrl ?? "") + (requestBuilder.path ?? "")) {
+        if let url = URL(string: requestBuilder.buildUrl()) {
             let urlRequest = NSMutableURLRequest(url: url, cachePolicy: requestBuilder.nsCachePolicy(), timeoutInterval: TimeInterval(requestBuilder.timeout ?? Constants.DEFAULT_TIMEOUT_DURATION_IN_SECONDS))
             urlRequest.httpMethod = requestBuilder.method.name.uppercased()
 


### PR DESCRIPTION
Add parameters to RequestBuilder and add centralized build url function with encoded query parameters

## Description
Before, the url was "manually" built at different place. Also query parameters weren't encoded

Also put in place the test unit framework to test the new code

It's not a breaking change because the old way (using the path) will still work for valid or manually encoded url

## Motivation and Context
The goal was to encode the query parameters in a centralized function.

Before, when there was an "invalid" character in a query parameter (like a space), the URL could not be built in the `execute` function of `TrikotHttpRequest.swift` and an error was returned

## How Has This Been Tested?
- The new code is unit tested
- It was tested in a project with a api call needing a json query parameter

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
